### PR TITLE
feat(keep-a-changelog): Add $REQUEST_BODY_FILE for curl request and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Renamed "Changelog AI" hooks to "PartCAD: Update CHANGELOG.md"
 - Renamed "Git Commit AI" hooks to "PartCAD: Prepare Commit Message"
 - Improved cleanup mechanism for temporary files
+- Added $REQUEST_BODY_FILE for curl request and cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,4 +107,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Renamed "Changelog AI" hooks to "PartCAD: Update CHANGELOG.md"
 - Renamed "Git Commit AI" hooks to "PartCAD: Prepare Commit Message"
 - Improved cleanup mechanism for temporary files
+
+## [1.8.1] - 2024-12-12
+
 - Added $REQUEST_BODY_FILE for curl request and cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,4 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.8.1] - 2024-12-12
 
+### Added
+
 - Added $REQUEST_BODY_FILE for curl request and cleanup.
+- Secure permissions on temporary files - `chmod 600`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![GitHub Release](https://img.shields.io/github/v/release/partcad/pre-commit)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![Keep a Changelog v1.1.0 badge][changelog-badge]][changelog] [![Apache 2.0 License Badge][license-badge]][license]
+
 # `pre-commit` - Git Hooks backed by AI
 
 Fed up with crafting commit messages by hand?
@@ -217,3 +221,8 @@ Join `#pre-commit` channel on
 [Apache License 2.0]: https://github.com/partcad/pre-commit/blob/main/.github/LICENSE
 [`mrgoonie/cmai.git`]: https://github.com/mrgoonie/cmai
 [MIT]: https://github.com/mrgoonie/cmai/tree/3398ab52778b999fa170a734411be6d69c4f1697?tab=readme-ov-file#license
+[changelog]: ./CHANGELOG.md
+[changelog-badge]: https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.1.0-%23E05735
+[license]: ./.github/LICENSE
+[version-badge]: https://img.shields.io/badge/version-1.8.1-blue.svg
+[license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg

--- a/keep-a-changelog.sh
+++ b/keep-a-changelog.sh
@@ -232,6 +232,11 @@ if [ ! -f "$REQUEST_BODY_FILE" ]; then
     echo "ERROR: Failed to create temporary file"
     exit 1
 fi
+chmod 600 "$REQUEST_BODY_FILE" || {
+    echo "ERROR: Failed to set secure permissions on temporary file"
+    rm -f "$REQUEST_BODY_FILE"
+    exit 1
+}
 echo "$REQUEST_BODY" > "$REQUEST_BODY_FILE"
 debug_log "Request body saved to $REQUEST_BODY_FILE"
 

--- a/prepare-commit-msg.sh
+++ b/prepare-commit-msg.sh
@@ -242,15 +242,22 @@ debug_log "Cleaning up temporary files"
 rm -v "$PROMPT_FILE" "$SYSTEM_PROMPT_FILE"
 
 REQUEST_BODY_FILE=$(mktemp)
+if [ ! -f "$REQUEST_BODY_FILE" ]; then
+    echo "ERROR: Failed to create temporary file"
+    exit 1
+fi
 echo "$REQUEST_BODY" > "$REQUEST_BODY_FILE"
 debug_log "Request body saved to $REQUEST_BODY_FILE"
 
 # Make the API request
 debug_log "Making API request to OpenRouter"
-RESPONSE=$(curl -s -X POST "https://openrouter.ai/api/v1/chat/completions" \
+if ! RESPONSE=$(curl -s -X POST "https://openrouter.ai/api/v1/chat/completions" \
     -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
     -H "Content-Type: application/json" \
-    -d @"$REQUEST_BODY_FILE")
+    -d @"$REQUEST_BODY_FILE"); then
+    echo "ERROR: API request failed with exit code $?"
+    exit 1
+fi
 debug_log "API response received" "$RESPONSE"
 debug_log "Cleaning up temporary files"
 rm -v "$REQUEST_BODY_FILE"

--- a/prepare-commit-msg.sh
+++ b/prepare-commit-msg.sh
@@ -246,6 +246,11 @@ if [ ! -f "$REQUEST_BODY_FILE" ]; then
     echo "ERROR: Failed to create temporary file"
     exit 1
 fi
+chmod 600 "$REQUEST_BODY_FILE" || {
+    echo "ERROR: Failed to set secure permissions on temporary file"
+    rm -f "$REQUEST_BODY_FILE"
+    exit 1
+}
 echo "$REQUEST_BODY" > "$REQUEST_BODY_FILE"
 debug_log "Request body saved to $REQUEST_BODY_FILE"
 


### PR DESCRIPTION
- Added `$REQUEST_BODY_FILE` for curl request and cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced pre-commit hooks for managing CHANGELOG.md updates and commit message generation.
	- Added support for configuring output directory and included instructions for hook configuration.
	- Implemented a `fail_fast` flag for the Changelog AI hook and enabled passing filenames to the commit-msg hook.
	- Added a new variable for handling curl requests.

- **Bug Fixes**
	- Resolved issues with hook execution and corrected typos in configuration.
	- Improved error handling in API response management.
	- Enhanced error handling for temporary file creation and API requests.

- **Documentation**
	- Updated documentation for clarity and guidance on new features and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->